### PR TITLE
fix: Remove unused image  import and css import causing unresolved de…

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,15 +1,15 @@
 import React from "react"
 import { useState, useEffect } from "react"
-import { Link } from "react-router-dom"
+
 import Slider from 'react-slick';
 import aboutimage1 from '/images/aboutimage1.svg'
-import aboutimageone from '/images/aboutimageone.png'
+
 import Image3 from '../assets/image/Image3.svg'
 import Image2 from '../assets/image/Image2.svg'
 import Image22 from '/images/Image22.svg'
 
 
-import Image from '../assets/image/Image.svg'
+
 
 import headshottwo from '/images/headshottwo.png'
 import api from '../services/landingpageservices';


### PR DESCRIPTION
This PR resolves an issue where an unused import in the About component was causing an unresolved dependency error. Specifically, the import for 'Image' from '../assets/image/Image.svg' and more others were removed as it was not being utilized in the component.

Changes:
- Removed unused import of 'Image' from '../assets/image/Image.svg' in About.jsx.

This fix ensures cleaner code and resolves the unresolved dependency warning that occurred during the build process.

Fixes #<issue_number_if_applicable>
