### PR TITLE
Add 'start' script to package.json for combined build and server start

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview",
-    "server": "json-server -p3001 --watch db.json"
-  },
+  "dev": "vite",
+  "build": "vite build",
+  "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+  "preview": "vite preview",
+  "server": "json-server -p3001 --watch db.json",
+  "start": "npm run build && npm run server"
+},
   "dependencies": {
     "axios": "^1.7.2",
     "react": "^18.2.0",


### PR DESCRIPTION
Pull Request Description
This PR adds a new script called start to the package.json file. The start script combines the build process and server start into a single command. This makes it easier to build the project and start the server with a single command, improving the developer experience. 

The scripts section now includes:

dev: vite
build: vite build
lint: eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0
preview: vite preview
server: json-server -p3001 --watch db.json
start: npm run build && npm run server