### PR TITLE
Update base URL in landingpageservices.js to production server

### DIFF
--- a/src/services/landingpageservices.js
+++ b/src/services/landingpageservices.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const baseUrl = 'http://localhost:3001';
+const baseUrl = 'https://pamelas-pampered-pets-website-backend.onrender.com/';
 
 const getServices = async () => {
   try {


### PR DESCRIPTION
This PR updates the `baseUrl` in `landingpageservices.js` from the local development server to the production server. 

- Changed `baseUrl` from `http://localhost:3001` to `https://pamelas-pampered-pets-website-backend.onrender.com/`.

This change ensures that the landing page services use the production backend, enabling proper functionality for end-users accessing the deployed site.
