### PR TITLE
Fix Background Image Width in Testimonials Section

### DIFF
--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -128,7 +128,7 @@ const LandingPage = () => {
       </section>
 
   <section className="relative py-8">
-    <div className="absolute top-0 left-0 w-4/6 h-full bg-cover bg-center blur-md opacity-50" style={{ backgroundImage: "url('/images/aboutimage.png')" }}></div>
+    <div className="absolute top-0 left-0 w-full h-full bg-cover bg-center blur-md opacity-50" style={{ backgroundImage: "url('/images/aboutimage.png')" }}></div>
     <header className="sm:text-4xl md:text-5xl md:font-extrabold lg:font-extrabold relative z-10  text-center mb-8 text-4xl font-bold text-gray-900 ">
       What Others Are Saying About Pamela
     </header>


### PR DESCRIPTION
### Description

This PR addresses an issue with the background image width in the testimonials section of the `LandingPage` component.

### Changes Made

- Updated the width of the background image container from `w-4/6` to `w-full` to ensure it spans the entire width of the section.

### Reasons for Changes

The adjustment ensures that the background image covers the full width of the section, improving the visual consistency and presentation of the testimonials section.

### Testing and Validation

- Verified that the background image now spans the entire width of the section.
- Ensured that the change does not negatively impact the layout or other styling elements of the section.

Please review the changes and provide feedback.
