### PR TITLE
Fix extra space in export statement of landingpageservices.js

### DIFF
--- a/src/services/landingpageservices.js
+++ b/src/services/landingpageservices.js
@@ -24,4 +24,4 @@ const getServices = () => fetchData('/services');
 const getTestimonials = () => fetchData('/testimonials');
 const getStyles = () => fetchData('/styles');
 
-export default { getServices, getTestimonials, getStyles };
+export default { getServices, getTestimonials, getStyles};


### PR DESCRIPTION
### Summary
This PR addresses a minor code style issue in the `landingpageservices.js` file. Specifically, an extra space before the closing brace in the export statement has been removed.

### Changes
- Removed the extra space before the closing brace in the default export of `landingpageservices.js`.

### Impact
This change does not affect functionality but improves code consistency and adheres to standard formatting practices.

### Testing
- No new tests are required as this change is purely cosmetic and does not alter any logic or functionality.
